### PR TITLE
Automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,20 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    bundler:
+      applies-to: version-updates
+      patterns: [ "*" ]
+      update-types: [ "minor", "patch" ]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    github-actions:
+      applies-to: version-updates
+      patterns: [ "*" ]
+      update-types: [ "minor", "patch" ]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,62 @@
+name: Dependabot auto-merge
+
+# Merges dependabot's minor/patch pull requests once CI is green.
+# Major bumps are left open on purpose.
+
+on:
+  workflow_run:
+    workflows: [ CI ]
+    types: [ completed ]
+
+jobs:
+  merge:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Merge if this is a non-major dependabot update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          pr=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+                 --json number,title,author \
+                 --jq '.[] | select(.author.login | test("dependabot")) | "\(.number)\t\(.title)"')
+
+          if [ -z "$pr" ]; then
+            echo "No open dependabot pull request on $BRANCH, nothing to do."
+            exit 0
+          fi
+
+          number=${pr%%$'\t'*}
+          title=${pr#*$'\t'}
+          echo "Found #$number: $title"
+
+          case "$title" in
+            *"group with"*)
+              # Grouped pull requests only ever contain minor/patch updates,
+              # see the update-types in .github/dependabot.yml
+              ;;
+            "Bump "*" from "*" to "*)
+              from=${title##* from }
+              from=${from%% to *}
+              to=${title##* to }
+              if [ "${from%%.*}" != "${to%%.*}" ]; then
+                echo "Major bump ($from -> $to), leaving it open for review."
+                exit 0
+              fi
+              ;;
+            *)
+              echo "Unrecognised title, leaving it open for review."
+              exit 0
+              ;;
+          esac
+
+          gh pr merge --repo "$REPO" --squash --delete-branch "$number"

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
Version updates are now weekly and grouped into a single pull request per ecosystem instead of one per gem per day, and minor/patch ones merge themselves once CI is green. Major bumps stay open for review.

Also drop --ensure-latest from bin/brakeman: it turned CI red whenever a newer brakeman was released, independently of the scan result, which would now stall the auto-merge queue.