### PR TITLE
Make the library browsable on a phone

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,13 +1,13 @@
 module PaginationHelper
   CONTAINER_CLASSES = {
-    "cards" => "grid grid-cols-5 gap-8",
+    "cards" => "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 lg:gap-8",
     "list" => "flex flex-col divide-y divide-gray-100 rounded-lg border border-gray-100 bg-white shadow-sm"
   }.freeze
 
   # A page after the first sits inside the container above it, so it repeats the
   # layout but not the frame around it.
   PAGE_CLASSES = {
-    "cards" => "col-span-full grid grid-cols-5 gap-8",
+    "cards" => "col-span-full grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 lg:gap-8",
     "list" => "flex flex-col divide-y divide-gray-100"
   }.freeze
 

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -1,10 +1,10 @@
 <% if @page == 1 %>
-<div class="mb-8 min-w-full flex items-start gap-4">
+<div class="mb-4 sm:mb-8 flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-4">
     <div class="flex-grow">
         <%= render "shared/search_form", path: current_authors_path, placeholder: t(".search_placeholder"), turbo_frame: "authors" %>
     </div>
 
-    <div class="shrink-0 py-5 sm:py-6">
+    <div class="shrink-0 sm:py-6">
         <%= render "shared/view_toggle" %>
     </div>
 </div>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto">
+<div class="max-w-7xl mx-auto px-4 sm:px-0">
   <div class="mb-8">
     <%= link_to current_authors_path, class: "inline-flex items-center text-sm text-gray-500 hover:text-gray-700" do %>
       <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -9,16 +9,16 @@
   </div>
 
   <div class="bg-white shadow rounded-lg">
-    <div class="px-6 py-8">
-      <div class="flex items-start justify-between">
+    <div class="px-4 py-6 sm:px-6 sm:py-8">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 class="text-3xl font-bold text-gray-900 mb-2"><%= @author.name %></h1>
+          <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2"><%= @author.name %></h1>
           <p class="text-lg text-gray-600 mb-6">
             <%= t(".books_by_author", count: @books.count) %>
           </p>
         </div>
 
-        <div class="flex items-center space-x-3">
+        <div class="flex flex-wrap items-center gap-3">
           <% unless browsing_other_library? %>
             <%= link_to edit_author_path(@author),
                 class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" do %>
@@ -47,7 +47,7 @@
     <h2 class="text-xl font-semibold text-gray-900 mb-6"><%= t(".books_heading", name: @author.name) %></h2>
 
     <% if @books.any? %>
-      <div class="grid grid-cols-5 gap-8">
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 lg:gap-8">
         <% @books.each do |book| %>
           <article class="overflow-hidden rounded-lg border border-gray-100 bg-white shadow-sm">
             <%= render "books/book_modal", book: book %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,10 +1,10 @@
 <% if @page == 1 %>
-<div class="mb-8 min-w-full flex items-start gap-4">
+<div class="mb-4 sm:mb-8 flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-4">
     <div class="flex-grow">
         <%= render "shared/search_form", path: current_books_path, placeholder: t(".search_placeholder"), turbo_frame: "books", extra_fields: "books/filters" %>
     </div>
 
-    <div class="shrink-0 py-5 sm:py-6">
+    <div class="shrink-0 sm:py-6">
         <%= render "shared/view_toggle" %>
     </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,10 +24,10 @@
 
   <body>
     <header class="px-4 sm:px-6 lg:px-8">
-      <div class="flex items-center justify-between border-b border-zinc-100 py-3 text-sm min-h-16">
+      <div class="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-100 py-3 text-sm min-h-16">
         <div class="flex items-center gap-4">
           <a href="/">
-            <%= image_tag("logo-no-background.svg", class: "max-w-56") %>
+            <%= image_tag("logo-no-background.svg", class: "max-w-40 sm:max-w-56") %>
           </a>
         </div>
         <% if current_user %>
@@ -35,7 +35,7 @@
           <% unless browsing_other_library? %>
             <%= form_with url: upload_books_path, multipart: true, local: true,
                 data: { controller: "upload", action: "change->upload#handleFiles" },
-                class: "mr-4" do |form| %>
+                class: "sm:mr-4" do |form| %>
               <%= form.file_field :files, multiple: true, accept: ".epub",
                   class: "hidden", id: "epub-file-input",
                   data: { upload_target: "fileInput" } %>
@@ -45,15 +45,37 @@
             <% end %>
           <% end %>
 
-            <%= link_to t(".sign_out"), session_path, data: { turbo_method: :delete }, class: "inline-block rounded-sm border border-indigo-600 px-12 py-3 text-sm font-medium text-indigo-600 hover:bg-indigo-600 hover:text-white focus:ring-3 focus:outline-hidden" %>
+            <%= link_to t(".sign_out"), session_path, data: { turbo_method: :delete }, class: "inline-block rounded-sm border border-indigo-600 px-4 py-2 sm:px-12 sm:py-3 text-sm font-medium text-indigo-600 hover:bg-indigo-600 hover:text-white focus:ring-3 focus:outline-hidden" %>
           </div>
         <% end %>
       </div>
     </header>
 
+    <% if current_user %>
+      <%# The sidebar is desktop only, so the same destinations sit here on a phone. %>
+      <nav class="lg:hidden overflow-x-auto border-b border-zinc-100 bg-white">
+        <ul class="flex items-center gap-1 whitespace-nowrap px-3 py-2 text-sm font-medium text-gray-500">
+          <% if browsing_other_library? %>
+            <li class="px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600">
+              <%= current_library_owner.display_name %>
+            </li>
+          <% end %>
+          <li><%= link_to t(".series"), current_series_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+          <li><%= link_to t(".authors"), current_authors_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+          <li><%= link_to t(".books"), current_books_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+          <li aria-hidden="true" class="mx-1 h-4 w-px shrink-0 bg-zinc-200"></li>
+          <% if browsing_other_library? %>
+            <li><%= link_to t(".back_to_my_library"), books_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+          <% end %>
+          <li><%= link_to t(".public_libraries"), libraries_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+          <li><%= link_to t(".edit_profile"), edit_profile_path, class: "block rounded-lg px-3 py-2 hover:bg-gray-100 hover:text-gray-700" %></li>
+        </ul>
+      </nav>
+    <% end %>
+
     <div class="flex">
       <% if current_user %>
-        <div class="flex h-screen flex-col justify-between border-e border-zinc-100 bg-white sticky top-0">
+        <div class="hidden lg:flex h-screen flex-col justify-between border-e border-zinc-100 bg-white sticky top-0">
           <div class="px-4 py-6 min-w-64">
             <!-- Library Owner Section -->
             <div class="mb-6">
@@ -213,7 +235,7 @@
           </div>
         <% end %>
 
-        <main class="container mx-auto mt-6 px-5 flex flex-col">
+        <main class="container mx-auto mt-6 px-3 sm:px-5 flex flex-col">
           <%= yield %>
         </main>
       </div>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -1,10 +1,10 @@
 <% if @page == 1 %>
-<div class="mb-8 min-w-full flex items-start gap-4">
+<div class="mb-4 sm:mb-8 flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-4">
     <div class="flex-grow">
         <%= render "shared/search_form", path: current_series_path, placeholder: t(".search_placeholder"), turbo_frame: "series", extra_fields: "series/filters" %>
     </div>
 
-    <div class="shrink-0 py-5 sm:py-6 flex items-center gap-3">
+    <div class="shrink-0 sm:py-6 flex flex-wrap items-center gap-3">
         <%= render "shared/view_toggle" %>
 
         <% unless browsing_other_library? %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto">
+<div class="max-w-7xl mx-auto px-4 sm:px-0">
   <div class="mb-8">
     <%= link_to current_series_path, class: "inline-flex items-center text-sm text-gray-500 hover:text-gray-700" do %>
       <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -9,12 +9,12 @@
   </div>
 
   <div class="bg-white shadow rounded-lg">
-    <div class="px-6 py-8">
-      <div class="flex items-start justify-between">
+    <div class="px-4 py-6 sm:px-6 sm:py-8">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 class="text-3xl font-bold text-gray-900 mb-2"><%= @serie.name %></h1>
+          <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2"><%= @serie.name %></h1>
 
-          <div class="flex items-center space-x-4 mb-6">
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mb-6">
             <p class="text-lg text-gray-600">
               <%= t(".books_in_series", count: @books.count) %>
             </p>
@@ -78,7 +78,7 @@
           <% end %>
         </div>
 
-        <div class="flex items-center space-x-3">
+        <div class="flex flex-wrap items-center gap-3">
           <% unless browsing_other_library? %>
             <%= link_to edit_serie_path(@serie),
                 class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" do %>
@@ -115,7 +115,7 @@
     <h2 class="text-xl font-semibold text-gray-900 mb-6"><%= t(".books_heading", name: @serie.name) %></h2>
 
     <% if @books.any? %>
-      <div class="grid grid-cols-5 gap-8">
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 lg:gap-8">
         <% @books.each do |book| %>
           <article class="overflow-hidden rounded-lg border border-gray-100 bg-white shadow-sm relative">
             <% if book.serie_index.present? %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-white sm:rounded-sm">
-    <div class="px-4 py-5 sm:p-6">
+    <div class="py-3 sm:p-6">
         <%= form_with url: path, method: :get, local: true,
             data: {
             controller: "search",

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -62,10 +62,14 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
 
       it "lays a later page out like the one it continues" do
         get series_url
-        _(css_select("turbo-frame#series_page_2").first["class"]).must_equal "col-span-full grid grid-cols-5 gap-8"
+        cards = css_select("turbo-frame#series_page_2").first["class"]
+        _(cards).must_match(/\bgrid\b/)
+        _(cards).must_include "col-span-full" # so its rows join the grid above
 
         get series_url(view: "list")
-        _(css_select("turbo-frame#series_page_2").first["class"]).must_equal "flex flex-col divide-y divide-gray-100"
+        rows = css_select("turbo-frame#series_page_2").first["class"]
+        _(rows).must_include "divide-y"
+        _(rows).wont_match(/\bgrid\b/)
       end
 
       it "shows each serie on exactly one page" do
@@ -94,7 +98,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
 
     it "renders the card grid by default and the list rows when view=list" do
       get series_url
-      _(response.body).must_include "grid grid-cols-5"
+      _(response.body).must_include "grid grid-cols-2"
 
       get series_url(view: "list")
       _(response.body).must_include "divide-y"
@@ -111,7 +115,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
     it "ignores an invalid view value" do
       get series_url(view: "bogus")
 
-      _(response.body).must_include "grid grid-cols-5"
+      _(response.body).must_include "grid grid-cols-2"
     end
 
     it "filters to unfinished series with filter=to_read" do


### PR DESCRIPTION
Logged in on a 390px viewport, the pages were unusable: the sidebar is a fixed 256px inside a flex row, which left about 130px for the content, and the browse grids were a hard grid-cols-5, so cards rendered as slivers about 25px wide. The series page came out 644px wide and a serie's page 907px, both in a 390px viewport.

The sidebar is now desktop only, with the same destinations in a scrollable row under the header on small screens. The browse grids go 2 / 3 / 4 / 5 columns as the viewport allows, in the one place those classes live, and the two show pages use the same shape. The header bar, the search row and the show page headers stack instead of overflowing, and the phone gets tighter padding.

Measured with chrome emulating a 390px viewport: every browse page now fits, with nothing wider than the viewport except the nav row, which scrolls on purpose. Desktop is unchanged, still five across with the sidebar.

The pagination test no longer pins the exact class list, just that a later page repeats the layout of the container it lands in.